### PR TITLE
HttpClient is explicit dependency now, so user can configure it

### DIFF
--- a/Funogram.TestBot/Program.fs
+++ b/Funogram.TestBot/Program.fs
@@ -38,7 +38,7 @@ let processMessageBuild config =
     let processResult (result: Result<'a, ApiResponseError>) =
         processResultWithValue result |> ignore
 
-    let botResult data = api config.Client config.Token data |> Async.RunSynchronously
+    let botResult data = api config data |> Async.RunSynchronously
     let bot data = botResult data |> processResult
 
 

--- a/Funogram.TestBot/Program.fs
+++ b/Funogram.TestBot/Program.fs
@@ -1,110 +1,123 @@
 ﻿module Funogram.TestBot
 
-open System
 open System.IO
 open Funogram.Api
 open Funogram.Types
 open Funogram.Bot
 open FunHttp
+open System.Net.Http
 
 
 [<Literal>]
 let TokenFileName = "token"
 let mutable botToken = "none"
 
-let defaultText = """⭐️Available test commands:
-/send_message1 - Markdown test
-/send_message2 - HTML test
-/send_message3 - Disable web page preview and notifications
-/send_message4 - Test reply message
-/send_message5 - Test ReplyKeyboardMarkup
-/send_message6 - Test RemoveKeyboardMarkup
+let processMessageBuild config = 
 
-/forward_message - Test forward message
-/show_my_photos_sizes - Test getUserProfilePhotos method
-/get_chat_info - Returns id and type of current chat
-/send_photo - Send example photo"""
+    let defaultText = """⭐️Available test commands:
+    /send_message1 - Markdown test
+    /send_message2 - HTML test
+    /send_message3 - Disable web page preview and notifications
+    /send_message4 - Test reply message
+    /send_message5 - Test ReplyKeyboardMarkup
+    /send_message6 - Test RemoveKeyboardMarkup
+
+    /forward_message - Test forward message
+    /show_my_photos_sizes - Test getUserProfilePhotos method
+    /get_chat_info - Returns id and type of current chat
+    /send_photo - Send example photo"""
 
 
-let processResultWithValue (result: Result<'a, ApiResponseError>) =
-    match result with
-    | Ok v -> Some v
-    | Error e -> 
-        printfn "Error: %s" e.Description 
-        None
+    let processResultWithValue (result: Result<'a, ApiResponseError>) =
+        match result with
+        | Ok v -> Some v
+        | Error e -> 
+            printfn "Error: %s" e.Description 
+            None
+            
+    let processResult (result: Result<'a, ApiResponseError>) =
+        processResultWithValue result |> ignore
+
+    let botResult data = api config.Client config.Token data |> Async.RunSynchronously
+    let bot data = botResult data |> processResult
+
+
+    let getChatInfo msg =
+        let result = botResult (getChat msg.Chat.Id)
+        match result with
+        | Ok x -> 
+            botResult (sendMessage msg.Chat.Id (sprintf "Id: %i, Type: %s" x.Id x.Type)) 
+            |> processResultWithValue 
+            |> ignore
+        | Error e -> printf "Error: %s" e.Description
+
+    let sendPhoto msg =
+        let image = Http.RequestStream("https://upload.wikimedia.org/wikipedia/commons/f/f5/Example_image.jpg")
+        bot (sendPhoto msg.Chat.Id (FileToSend.File("example.jpg", image.ResponseStream)) "Example")
+
+    let updateArrived ctx = 
+        let fromId() = ctx.Update.Message.Value.From.Value.Id
+        let sayWithArgs text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup = 
+            bot (sendMessageBase (ChatId.Int (fromId())) text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup)
+
+        let sendMessageFormatted text parseMode = bot (sendMessageBase (ChatId.Int(fromId())) text (Some parseMode) None None None None)
         
-let processResult (result: Result<'a, ApiResponseError>) =
-    processResultWithValue result |> ignore
+        let result =
+            processCommands ctx [
+                cmd "/send_message1" (fun _ -> sendMessageFormatted "Test *Markdown*" ParseMode.Markdown)
+                cmd "/send_message2" (fun _ -> sendMessageFormatted "Test <b>HTML</b>" ParseMode.HTML)
+                cmd "/send_message3" (fun _ -> sayWithArgs "@Dolfik! See http://fsharplang.ru - Russian F# Community" None (Some true) (Some true) None None)
+                cmd "/send_message4" (fun _ -> sayWithArgs "That's message with reply!" None None None (Some ctx.Update.Message.Value.MessageId) None)
+                cmd "/send_message5" (fun _ -> 
+                (
+                    let keyboard = (Seq.init 2 (fun x -> Seq.init 2 (fun y -> { Text = y.ToString() + x.ToString(); RequestContact = None; RequestLocation = None })))
+                    let markup = Markup.ReplyKeyboardMarkup {  
+                        Keyboard = keyboard
+                        ResizeKeyboard = None
+                        OneTimeKeyboard = None
+                        Selective = None
+                    }
+                    bot (sendMessageMarkup (fromId()) "That's keyboard!" markup)
+                ))
+                cmd "/send_message6" (fun _ ->
+                (
+                    let markup = Markup.ReplyKeyboardRemove { RemoveKeyboard = true; Selective = None; }
+                    bot (sendMessageMarkup (fromId()) "Keyboard was removed!" markup)
+                ))
+                cmd "/forward_message" (fun _ -> bot (forwardMessage (fromId()) (fromId()) ctx.Update.Message.Value.MessageId))
+                cmd "/show_my_photos_sizes" (fun _ -> 
+                (
+                    let x = botResult (getUserProfilePhotosAll (fromId())) |> processResultWithValue
+                    if x.IsNone then ()
+                    else
+                        let text = sprintf "Photos: %s" (x.Value.Photos 
+                                    |> Seq.map (Seq.last >> (fun f -> sprintf "%ix%i" f.Width f.Height))
+                                    //|> Seq.map (fun f -> sprintf "%ix%i" f.Width f.Height)
+                                    |> String.concat ",")
+                        
+                        bot (sendMessage (fromId()) text)
+                ))
+                cmd "/get_chat_info" (fun _ -> getChatInfo ctx.Update.Message.Value)
+                cmd "/send_photo" (fun _ -> sendPhoto ctx.Update.Message.Value)
+            ]
 
-let bot data = api botToken data |> Async.RunSynchronously |> processResult
-let botResult data = api botToken data |> Async.RunSynchronously
-
-let getChatInfo msg =
-    let result = botResult (getChat msg.Chat.Id)
-    match result with
-    | Ok x -> 
-        botResult (sendMessage msg.Chat.Id (sprintf "Id: %i, Type: %s" x.Id x.Type)) 
-        |> processResultWithValue 
-        |> ignore
-    | Error e -> printf "Error: %s" e.Description
-
-let sendPhoto msg =
-    let image = Http.RequestStream("https://upload.wikimedia.org/wikipedia/commons/f/f5/Example_image.jpg")
-    bot (sendPhoto msg.Chat.Id (FileToSend.File("example.jpg", image.ResponseStream)) "Example")
-
-let updateArrived ctx = 
-    let fromId() = ctx.Update.Message.Value.From.Value.Id
- 
-    let sayWithArgs text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup = 
-        bot (sendMessageBase (ChatId.Int (fromId())) text parseMode disableWebPagePreview disableNotification replyToMessageId replyMarkup)
-
-    let sendMessageFormatted text parseMode = bot (sendMessageBase (ChatId.Int(fromId())) text (Some parseMode) None None None None)
-    
-    let result =
-        processCommands ctx [
-            cmd "/send_message1" (fun _ -> sendMessageFormatted "Test *Markdown*" ParseMode.Markdown)
-            cmd "/send_message2" (fun _ -> sendMessageFormatted "Test <b>HTML</b>" ParseMode.HTML)
-            cmd "/send_message3" (fun _ -> sayWithArgs "@Dolfik! See http://fsharplang.ru - Russian F# Community" None (Some true) (Some true) None None)
-            cmd "/send_message4" (fun _ -> sayWithArgs "That's message with reply!" None None None (Some ctx.Update.Message.Value.MessageId) None)
-            cmd "/send_message5" (fun _ -> 
-            (
-                let keyboard = (Seq.init 2 (fun x -> Seq.init 2 (fun y -> { Text = y.ToString() + x.ToString(); RequestContact = None; RequestLocation = None })))
-                let markup = Markup.ReplyKeyboardMarkup {  
-                    Keyboard = keyboard
-                    ResizeKeyboard = None
-                    OneTimeKeyboard = None
-                    Selective = None
-                }
-                bot (sendMessageMarkup (fromId()) "That's keyboard!" markup)
-            ))
-            cmd "/send_message6" (fun _ ->
-            (
-                let markup = Markup.ReplyKeyboardRemove { RemoveKeyboard = true; Selective = None; }
-                bot (sendMessageMarkup (fromId()) "Keyboard was removed!" markup)
-            ))
-            cmd "/forward_message" (fun _ -> bot (forwardMessage (fromId()) (fromId()) ctx.Update.Message.Value.MessageId))
-            cmd "/show_my_photos_sizes" (fun _ -> 
-            (
-                let x = botResult (getUserProfilePhotosAll (fromId())) |> processResultWithValue
-                if x.IsNone then ()
-                else
-                    let text = sprintf "Photos: %s" (x.Value.Photos 
-                                |> Seq.map Seq.last
-                                |> Seq.map (fun f -> sprintf "%ix%i" f.Width f.Height)
-                                |> String.concat ",")
-                    
-                    bot (sendMessage (fromId()) text)
-            ))
-            cmd "/get_chat_info" (fun _ -> getChatInfo ctx.Update.Message.Value)
-            cmd "/send_photo" (fun _ -> sendPhoto ctx.Update.Message.Value)
-        ]
-
-    if result then ()
-    else bot (sendMessage (fromId()) defaultText)
+        if result then ()
+        else bot (sendMessage (fromId()) defaultText)
+    updateArrived    
 
 let start token =
-    botToken <- token
+    (*
+    * Set poxy
+    *```fsharp
+    * let handler = new HttpClientHadler ()
+    * handler.Proxy <- createMyProxy ()
+    * handler.UseProxy <- true
+    * let config = { defaultConfig with Token = token
+    *                                   Cleint = new HttpClient(handler, true) }
+    *```
+    *)
     let config = { defaultConfig with Token = token }
+    let updateArrived = processMessageBuild config
     startBot config updateArrived None
 
 [<EntryPoint>]

--- a/Funogram.Tests/Json.fs
+++ b/Funogram.Tests/Json.fs
@@ -8,7 +8,7 @@ open Extensions
 
 [<Fact>]
 let ``JSON deserializing MessageEntity`` () =
-    let a = Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString)
+    let _ = Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString)
     
     match Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString) with
         | Ok r -> shouldEqual r Constants.jsonTestObj

--- a/Funogram.Tests/Json.fs
+++ b/Funogram.Tests/Json.fs
@@ -8,9 +8,9 @@ open Extensions
 
 [<Fact>]
 let ``JSON deserializing MessageEntity`` () =
-    let _ = Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString)
+    let a = Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString)
     
-    match Tools.parseJson<MessageEntity>(Constants.jsonTestObjResultString) with
+    match a with
         | Ok r -> shouldEqual r Constants.jsonTestObj
         | Error e -> failwith(e.Description)
 

--- a/Funogram/Api.fs
+++ b/Funogram/Api.fs
@@ -11,8 +11,8 @@ let private getArgs (body: IRequestBase<'a>) =
     let props = body.GetType().GetTypeInfo().GetProperties() |> Array.toList
     props |> List.map (fun f -> (getSnakeCaseName f.Name, f.GetValue(body)))
 
-let api (token: string) (body: IRequestBase<'a>) = 
-    Api.MakeRequestAsync<'a> (token, body.MethodName, (getArgs body))
+let api client (token: string) (body: IRequestBase<'a>) = 
+    Api.MakeRequestAsync<'a> (client, token, body.MethodName, (getArgs body))
 
 let getUpdatesBase offset limit timeout allowedUpdates =
     { Offset = offset; Limit = limit; Timeout = timeout; AllowedUpdates = allowedUpdates }

--- a/Funogram/Api.fs
+++ b/Funogram/Api.fs
@@ -6,13 +6,22 @@ open Funogram.Tools
 
 open System.Reflection
 open JsonConverters
+open System.Net.Http
+
+type BotConfig = 
+    { Token : string
+      Offset : int64 option
+      Limit : int option
+      Timeout : int option
+      AllowedUpdates : string seq option
+      Client : HttpClient }
 
 let private getArgs (body: IRequestBase<'a>) =
     let props = body.GetType().GetTypeInfo().GetProperties() |> Array.toList
     props |> List.map (fun f -> (getSnakeCaseName f.Name, f.GetValue(body)))
 
-let api client (token: string) (body: IRequestBase<'a>) = 
-    Api.MakeRequestAsync<'a> (client, token, body.MethodName, (getArgs body))
+let api config (body: IRequestBase<'a>) = 
+    Api.MakeRequestAsync<'a> (config.Client, config.Token, body.MethodName, (getArgs body))
 
 let getUpdatesBase offset limit timeout allowedUpdates =
     { Offset = offset; Limit = limit; Timeout = timeout; AllowedUpdates = allowedUpdates }

--- a/Funogram/Api.fs
+++ b/Funogram/Api.fs
@@ -4,7 +4,6 @@ open Funogram.Types
 open Funogram.RequestsTypes
 open Funogram.Tools
 
-open System
 open System.Reflection
 open JsonConverters
 

--- a/Funogram/Bot/Bot.fs
+++ b/Funogram/Bot/Bot.fs
@@ -5,13 +5,6 @@ open Funogram.Types
 open Funogram.Api
 open System.Net.Http
 
-type BotConfig = 
-    { Token : string
-      Offset : int64 option
-      Limit : int option
-      Timeout : int option
-      AllowedUpdates : string seq option
-      Client : HttpClient }
 
 let defaultConfig = 
     { Token = ""
@@ -65,7 +58,7 @@ let cmdScan (pf : PrintfFormat<_, _, _, _, 't>) (h : 't -> unit) =
     f
 
 let private runBot config me updateArrived updatesArrived = 
-    let bot data = api config.Client config.Token data
+    let bot data = api config data
     let rec loopAsync offset = 
         async { 
             try 
@@ -103,7 +96,7 @@ let private runBot config me updateArrived updatesArrived =
 let startBot config updateArrived updatesArrived = 
     let meResult = 
         getMe
-        |> api config.Client config.Token
+        |> api config
         |> Async.RunSynchronously
     match meResult with
     | Error e -> failwith (e.Description)

--- a/Funogram/Bot/Sscanf.fs
+++ b/Funogram/Bot/Sscanf.fs
@@ -1,7 +1,6 @@
 module internal Funogram.Sscanf
 
 open System
-open System.Text
 open System.Text.RegularExpressions
 open Microsoft.FSharp.Reflection
 
@@ -60,7 +59,7 @@ let rec getFormatters xs =
     | '%' :: x :: xr -> 
         if parsers.ContainsKey x then x :: getFormatters xr
         else failwithf "Unknown formatter %%%c" x
-    | x :: xr -> getFormatters xr
+    | _ :: xr -> getFormatters xr
     | [] -> []
 
 // Coerce integer types from int64
@@ -111,13 +110,13 @@ let sscanf (pf : PrintfFormat<_, _, _, _, 't>) s : 't =
 
 module private BasicTesting = 
     // some basic testing
-    let (a, b) = sscanf "(%%%s,%M)" "(%hello, 4.53)"
-    let aaa : int32 = sscanf "aaaa%d" "aaaa4"
-    let bbb : int64 = sscanf "aaaa%d" "aaaa4"
-    let (x, y, z) = sscanf "%s-%s-%s" "test-this-string"
-    let (c, d, e : uint32, f, g, h, i) = 
+    let (_, _) = sscanf "(%%%s,%M)" "(%hello, 4.53)"
+    let _ : int32 = sscanf "aaaa%d" "aaaa4"
+    let _ : int64 = sscanf "aaaa%d" "aaaa4"
+    let (_, _, _) = sscanf "%s-%s-%s" "test-this-string"
+    let (_, _, _ : uint32, _, _, _, _) = 
         sscanf "%b-%d-%i,%u,%x,%X,%o" "false-42--31,13,ff,FF,42"
-    let (j, k, l, m, n, o, p) = 
+    let (_, _, _, _, _, _, _) = 
         sscanf "%f %F %g %G %e %E %c" "1 2.1 3.4 .3 43.2e32 0 f"
 
 let aa = sscanf "(%s)" "(45.33)"

--- a/Funogram/Funogram.fsproj
+++ b/Funogram/Funogram.fsproj
@@ -13,7 +13,7 @@
     <Compile Include="Tools.fs" />
     <Compile Include="RequestsTypes.fs" />
     <!-- <Compile Include="api.fsi" /> -->
-    <Compile Include="api.fs" />
+    <Compile Include="Api.fs" />
     <Compile Include="Bot/Sscanf.fs" />
     <Compile Include="Bot/Bot.fs" />
   </ItemGroup>

--- a/Funogram/JsonHelpers.fs
+++ b/Funogram/JsonHelpers.fs
@@ -1,10 +1,8 @@
 module internal Funogram.JsonHelpers
 
 open Newtonsoft.Json
-open Newtonsoft.Json.Serialization
 open System
 open System.Reflection
-open FSharp.Reflection
 
 type InSnakeCaseAttribute() = 
     inherit System.Attribute()
@@ -17,9 +15,9 @@ type UnixDateTimeConverter() =
     let isOption (t : Type) = 
         t.GetTypeInfo().IsGenericType 
         && t.GetGenericTypeDefinition() = typedefof<option<_>>
-    override this.CanConvert objectType = objectType = typeof<DateTime>
+    override __.CanConvert objectType = objectType = typeof<DateTime>
     
-    override this.ReadJson(reader, objectType, existingValue, serializer) = 
+    override __.ReadJson(reader, objectType, _, _) = 
         if (isNull (reader.Value) && isOption objectType) then box None
         elif isNull (reader.Value) then box null
         else 
@@ -31,7 +29,7 @@ type UnixDateTimeConverter() =
             if isOption objectType then box (Some v)
             else box v
     
-    override this.WriteJson(writer, value, serializer) = 
+    override __.WriteJson(writer, value, serializer) = 
         let value = 
             if isNull value then null
             elif isOption (value.GetType()) then 

--- a/Funogram/RequestsTypes.fs
+++ b/Funogram/RequestsTypes.fs
@@ -12,11 +12,11 @@ type GetUpdatesReq =
       Timeout : int option
       AllowedUpdates : string seq }
     interface IRequestBase<Update seq> with
-        member x.MethodName = "getUpdates"
+        member __.MethodName = "getUpdates"
 
 type GetMeReq() = 
     interface IRequestBase<User> with
-        member x.MethodName = "getMe"
+        member __.MethodName = "getMe"
 
 type SendMessageReq = 
     { ChatId : ChatId
@@ -27,7 +27,7 @@ type SendMessageReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendMessage"
+        member __.MethodName = "sendMessage"
 
 let sendMessageReqBase = 
     { ChatId = ChatId.Int 0L
@@ -44,7 +44,7 @@ type ForwardMessageReq =
       MessageId : int64
       DisableNotification : bool option }
     interface IRequestBase<Message> with
-        member x.MethodName = "forwardMessage"
+        member __.MethodName = "forwardMessage"
 
 type SendPhotoReq = 
     { ChatId : ChatId
@@ -54,7 +54,7 @@ type SendPhotoReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendPhoto"
+        member __.MethodName = "sendPhoto"
 
 type SendAudioReq = 
     { ChatId : ChatId
@@ -67,7 +67,7 @@ type SendAudioReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendAudio"
+        member __.MethodName = "sendAudio"
 
 type SendDocumentReq = 
     { ChatId : ChatId
@@ -77,7 +77,7 @@ type SendDocumentReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendDocument"
+        member __.MethodName = "sendDocument"
 
 type SendStickerReq = 
     { ChatId : ChatId
@@ -86,7 +86,7 @@ type SendStickerReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendSticker"
+        member __.MethodName = "sendSticker"
 
 type SendVideoReq = 
     { ChatId : ChatId
@@ -99,7 +99,7 @@ type SendVideoReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendVideo"
+        member __.MethodName = "sendVideo"
 
 type SendVoiceReq = 
     { ChatId : ChatId
@@ -110,7 +110,7 @@ type SendVoiceReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendVoice"
+        member __.MethodName = "sendVoice"
 
 type SendVideoNoteReq = 
     { ChatId : ChatId
@@ -121,7 +121,7 @@ type SendVideoNoteReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendVideoNote"
+        member __.MethodName = "sendVideoNote"
 
 type SendLocationReq = 
     { ChatId : ChatId
@@ -131,7 +131,7 @@ type SendLocationReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendLocation"
+        member __.MethodName = "sendLocation"
 
 type SendVenueReq = 
     { ChatId : ChatId
@@ -144,7 +144,7 @@ type SendVenueReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendVenue"
+        member __.MethodName = "sendVenue"
 
 type SendContactReq = 
     { ChatId : ChatId
@@ -155,57 +155,57 @@ type SendContactReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendContact"
+        member __.MethodName = "sendContact"
 
 type SendChatActionReq = 
     { ChatId : ChatId
       Action : ChatAction }
     interface IRequestBase<bool> with
-        member x.MethodName = "sendChatAction"
+        member __.MethodName = "sendChatAction"
 
 type GetFileReq = 
     { FileId : string }
     interface IRequestBase<File> with
-        member x.MethodName = "getFile"
+        member __.MethodName = "getFile"
 
 type GetUserProfilePhotosReq = 
     { UserId : int64
       Offset : int option
       Limit : int option }
     interface IRequestBase<UserProfilePhotos> with
-        member x.MethodName = "getUserProfilePhotos"
+        member __.MethodName = "getUserProfilePhotos"
 
 type UnbanChatMemberReq = 
     { ChatId : ChatId
       UserId : int64 }
     interface IRequestBase<bool> with
-        member x.MethodName = "unbanChatMember"
+        member __.MethodName = "unbanChatMember"
 
 type LeaveChatReq = 
     { ChatId : ChatId }
     interface IRequestBase<bool> with
-        member x.MethodName = "leaveChat"
+        member __.MethodName = "leaveChat"
 
 type GetChatReq = 
     { ChatId : ChatId }
     interface IRequestBase<Chat> with
-        member x.MethodName = "getChat"
+        member __.MethodName = "getChat"
 
 type GetChatAdministratorsReq = 
     { ChatId : ChatId }
     interface IRequestBase<ChatMember seq> with
-        member x.MethodName = "getChatAdministrators"
+        member __.MethodName = "getChatAdministrators"
 
 type GetChatMembersCountReq = 
     { ChatId : ChatId }
     interface IRequestBase<int> with
-        member x.MethodName = "getChatMembersCount"
+        member __.MethodName = "getChatMembersCount"
 
 type GetChatMemberReq = 
     { ChatId : ChatId
       UserId : int64 }
     interface IRequestBase<ChatMember> with
-        member x.MethodName = "getChatMember"
+        member __.MethodName = "getChatMember"
 
 type RestrictChatMemberReq = 
     { ChatId : ChatId
@@ -216,7 +216,7 @@ type RestrictChatMemberReq =
       CanSendOtherMessages : bool option
       CanAddWebPagePreviews : bool option }
     interface IRequestBase<bool> with
-        member x.MethodName = "restrictChatMember"
+        member __.MethodName = "restrictChatMember"
 
 type PromoteChatMemberReq = 
     { ChatId : ChatId
@@ -230,54 +230,54 @@ type PromoteChatMemberReq =
       CanPinMessages : bool option
       CanPromoteMembers : bool option }
     interface IRequestBase<bool> with
-        member x.MethodName = "promoteChatMember"
+        member __.MethodName = "promoteChatMember"
 
 type KickChatMemberReq = 
     { ChatId : ChatId
       UserId : int64
       UntilDate : DateTime option }
     interface IRequestBase<bool> with
-        member x.MethodName = "kickChatMember"
+        member __.MethodName = "kickChatMember"
 
 type ExportChatInviteLinkReq = 
     { ChatId : ChatId }
     interface IRequestBase<string> with
-        member x.MethodName = "exportChatInviteLink"
+        member __.MethodName = "exportChatInviteLink"
 
 type SetChatPhotoReq = 
     { ChatId : ChatId
       Photo : FileToSend }
     interface IRequestBase<string> with
-        member x.MethodName = "setChatPhoto"
+        member __.MethodName = "setChatPhoto"
 
 type DeleteChatPhotoReq = 
     { ChatId : ChatId }
     interface IRequestBase<string> with
-        member x.MethodName = "deleteChatPhoto"
+        member __.MethodName = "deleteChatPhoto"
 
 type SetChatTitleReq = 
     { ChatId : ChatId
       Title : string }
     interface IRequestBase<string> with
-        member x.MethodName = "setChatTitle"
+        member __.MethodName = "setChatTitle"
 
 type SetChatDescriptionReq = 
     { ChatId : ChatId
       Description : string }
     interface IRequestBase<string> with
-        member x.MethodName = "setChatDescription"
+        member __.MethodName = "setChatDescription"
 
 type PinChatMessageReq = 
     { ChatId : ChatId
       MessageId : int64
       DisableNotification : bool option }
     interface IRequestBase<bool> with
-        member x.MethodName = "pinChatMessage"
+        member __.MethodName = "pinChatMessage"
 
 type UnpinChatMessageReq = 
     { ChatId : ChatId }
     interface IRequestBase<bool> with
-        member x.MethodName = "unpinChatMessage"
+        member __.MethodName = "unpinChatMessage"
 
 type AnswerCallbackQueryReq = 
     { CallbackQueryId : string option
@@ -286,7 +286,7 @@ type AnswerCallbackQueryReq =
       Url : string option
       CacheTime : int option }
     interface IRequestBase<bool> with
-        member x.MethodName = "answerCallbackQuery"
+        member __.MethodName = "answerCallbackQuery"
 
 type EditMessageTextReq = 
     { Text : string
@@ -297,7 +297,7 @@ type EditMessageTextReq =
       DisableWebPagePreview : bool option
       ReplyMarkup : InlineKeyboardMarkup option }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "editMessageText"
+        member __.MethodName = "editMessageText"
 
 type EditMessageCaptionReq = 
     { ChatId : ChatId option
@@ -306,7 +306,7 @@ type EditMessageCaptionReq =
       Caption : string option
       ReplyMarkup : InlineKeyboardMarkup option }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "editMessageCaption"
+        member __.MethodName = "editMessageCaption"
 
 type EditMessageReplyMarkupReq = 
     { ChatId : ChatId option
@@ -314,13 +314,13 @@ type EditMessageReplyMarkupReq =
       InlineMessageId : string option
       ReplyMarkup : InlineKeyboardMarkup option }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "editMessageReplyMarkup"
+        member __.MethodName = "editMessageReplyMarkup"
 
 type DeleteMessageReq = 
     { ChatId : ChatId
       MessageId : int64 }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "deleteMessage"
+        member __.MethodName = "deleteMessage"
 
 type AnswerInlineQueryReq = 
     { InlineQueryId : string
@@ -331,7 +331,7 @@ type AnswerInlineQueryReq =
       SwitchPmText : string option
       SwitchPmParameter : string option }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "answerInlineQuery"
+        member __.MethodName = "answerInlineQuery"
 
 type SendInvoiceReq = 
     { ChatId : int64
@@ -354,7 +354,7 @@ type SendInvoiceReq =
       ReplyToMessageId : int option
       ReplyMarkup : InlineKeyboardMarkup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendInvoice"
+        member __.MethodName = "sendInvoice"
 
 type SendInvoiceArgs = 
     { PhotoUrl : string option
@@ -390,14 +390,14 @@ type AnswerShippingQueryReq =
       ShippingOptions : ShippingOption seq option
       ErrorMessage : string option }
     interface IRequestBase<bool> with
-        member x.MethodName = "answerShippingQuery"
+        member __.MethodName = "answerShippingQuery"
 
 type AnswerPreCheckoutQueryReq = 
     { PreCheckoutQueryId : string
       Ok : bool
       ErrorMessage : string option }
     interface IRequestBase<bool> with
-        member x.MethodName = "answerPreCheckoutQuery"
+        member __.MethodName = "answerPreCheckoutQuery"
 
 type SendGameReq = 
     { ChatId : int64
@@ -406,7 +406,7 @@ type SendGameReq =
       ReplyToMessageId : int64 option
       ReplyMarkup : Markup option }
     interface IRequestBase<Message> with
-        member x.MethodName = "sendGame"
+        member __.MethodName = "sendGame"
 
 type SetGameScoreReq = 
     { UserId : int64
@@ -417,7 +417,7 @@ type SetGameScoreReq =
       MessageId : int64 option
       InlineMessageId : string option }
     interface IRequestBase<EditMessageResult> with
-        member x.MethodName = "setGameScore"
+        member __.MethodName = "setGameScore"
 
 type GetGameHighScoresReq = 
     { UserId : int64
@@ -425,19 +425,19 @@ type GetGameHighScoresReq =
       MessageId : int64 option
       InlineMessageId : string option }
     interface IRequestBase<GameHighScore seq> with
-        member x.MethodName = "getGameHighScores"
+        member __.MethodName = "getGameHighScores"
 
 // Stickers
 type GetStickerSetReq = 
     { Name : string }
     interface IRequestBase<StickerSet> with
-        member x.MethodName = "getStickerSet"
+        member __.MethodName = "getStickerSet"
 
 type UploadStickerFileReq = 
     { UserId : int64
       PngSticker : File }
     interface IRequestBase<File> with
-        member x.MethodName = "uploadStickerFile"
+        member __.MethodName = "uploadStickerFile"
 
 type CreateNewStickerSetReq = 
     { UserId : int64
@@ -448,7 +448,7 @@ type CreateNewStickerSetReq =
       ContainsMasks : bool option
       MaskPosition : MaskPosition option }
     interface IRequestBase<bool> with
-        member x.MethodName = "createNewStickerSet"
+        member __.MethodName = "createNewStickerSet"
 
 type AddStickerToSetReq = 
     { UserId : int64
@@ -457,15 +457,15 @@ type AddStickerToSetReq =
       Emojis : string
       MaskPosition : MaskPosition option }
     interface IRequestBase<bool> with
-        member x.MethodName = "addStickerToSet"
+        member __.MethodName = "addStickerToSet"
 
 type SetStickerPositionInSetReq = 
     { Sticker : string
       Position : int }
     interface IRequestBase<bool> with
-        member x.MethodName = "setStickerPositionInSet"
+        member __.MethodName = "setStickerPositionInSet"
 
 type DeleteStickerFromSet = 
     { Sticker : string }
     interface IRequestBase<bool> with
-        member x.MethodName = "deleteStickerFromSet"
+        member __.MethodName = "deleteStickerFromSet"

--- a/Funogram/Tools.fs
+++ b/Funogram/Tools.fs
@@ -72,11 +72,11 @@ let internal (|SomeObj|_|) =
             else Some(v.GetValue(a, [||]))
         else None
 
-let mutable private clientLazy = lazy (new HttpClient())
+// let private clientLazy  =  lazy ( new HttpClient())
 
 [<AbstractClass>]
 type internal Api private () = 
-    static member private Client = clientLazy.Value
+    // static member private Client  = clientLazy.Value
     
     static member private ConvertParameterValue(value : obj) : HttpContent * string option = 
         let typeInfo = value.GetType().GetTypeInfo()
@@ -110,13 +110,14 @@ type internal Api private () =
                 else Some(v.GetValue(a, [||]))
             else None
     
-    static member internal MakeRequestAsync<'a>(token : string, 
+    static member internal MakeRequestAsync<'a>(client: HttpClient,
+                                                token : string, 
                                                 methodName : string, 
                                                 ?param : (string * obj) list) = 
         async { 
             let url = getUrl token methodName
             if param.IsNone || param.Value.Length = 0 then 
-                return Api.Client.GetStringAsync(url)
+                return client.GetStringAsync(url)
                        |> Async.AwaitTask
                        |> Async.RunSynchronously
                        |> parseJson<'a>
@@ -141,7 +142,7 @@ type internal Api private () =
                                                (content, name, fileName.Value)
                                        else form.Add(content, name))
                     let result = 
-                        Api.Client.PostAsync(url, form)
+                        client.PostAsync(url, form)
                         |> Async.AwaitTask
                         |> Async.RunSynchronously
                     return parseJson<'a> (result.Content.ReadAsStringAsync()
@@ -154,7 +155,7 @@ type internal Api private () =
                                           "application/json")
                     
                     let result = 
-                        Api.Client.PostAsync(url, result)
+                        client.PostAsync(url, result)
                         |> Async.AwaitTask
                         |> Async.RunSynchronously
                     return parseJson<'a> (result.Content.ReadAsStringAsync()

--- a/Funogram/Tools.fs
+++ b/Funogram/Tools.fs
@@ -13,7 +13,6 @@ open System.Text
 do ()
 
 open Types
-open JsonHelpers
 
 let private getUrl token methodName = 
     sprintf "https://api.telegram.org/bot%s/%s" token methodName
@@ -132,7 +131,7 @@ type internal Api private () =
                                                None
                                            else Some(key, value))
                 if paramValues 
-                   |> Seq.exists (fun (a, b) -> (b :? Types.FileToSend)) then 
+                   |> Seq.exists (fun (_, b) -> (b :? Types.FileToSend)) then 
                     use form = new MultipartFormDataContent()
                     paramValues |> Seq.iter (fun (name, value) -> 
                                        let content, fileName = 


### PR DESCRIPTION
HttpClient was created implicitly and it was impossible to configure it(for example it was impossible to set proxy)
Now HttpClient is a part of config, it's ok cause HttpClient [is a collection of settings](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=netframework-4.7.2#remarks) too.
Now it explicit, but does not require unnecessary attention.