### PR TITLE
Simplify processCommands API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 .vs
 packages
 Funogram.TestBot/token
+.idea/*

--- a/Funogram/Bot/Bot.fs
+++ b/Funogram/Bot/Bot.fs
@@ -32,10 +32,9 @@ let private getTextForCommand (me : User) (text : string option) =
 let cmd (command: string) (handler: UpdateContext -> unit) (context: UpdateContext) =
     context.Update.Message
     |> Option.bind (fun message -> getTextForCommand context.Me message.Text)
-    |> Option.map (fun text -> if text = command then handler context; true else false)
-    |> function 
-    | Some value -> value
-    | None -> false
+    |> Option.filter ((=) command)
+    |> Option.map (fun _ -> handler context)
+    |> Option.isSome
 
 let cmdScan (format: PrintfFormat<_, _, _, _, 't>) (handler: 't -> unit) (context: UpdateContext) = 
     let scan command = 
@@ -46,9 +45,7 @@ let cmdScan (format: PrintfFormat<_, _, _, _, 't>) (handler: 't -> unit) (contex
     |> Option.bind (fun message -> getTextForCommand context.Me message.Text)
     |> Option.bind scan
     |> Option.map handler
-    |> function 
-    | Some value -> true
-    | None -> false 
+    |> Option.isSome
 
 let private runBot config me updateArrived updatesArrived = 
     let bot data = api config.Token data
@@ -94,7 +91,6 @@ let startBot config updateArrived updatesArrived =
     |> function
     | Error error -> failwith error.Description
     | Ok me -> runBot config me updateArrived updatesArrived
-    |> ignore
 
 let processCommands (context: UpdateContext) =
     Seq.forall (fun command -> command context)

--- a/Funogram/Bot/Bot.fs
+++ b/Funogram/Bot/Bot.fs
@@ -29,35 +29,26 @@ let private getTextForCommand (me : User) (text : string option) =
         Some(text.Value.Replace(username(), ""))
     else text
 
-let cmd (command : string) (h : _ -> unit) = 
-    let f (r : Message, me : User) = 
-        match (getTextForCommand me r.Text) with
-        | Some text -> 
-            if text = command then 
-                h()
-                true
-            else false
-        | None -> false
-    f
+let cmd (command: string) (handler: UpdateContext -> unit) (context: UpdateContext) =
+    context.Update.Message
+    |> Option.bind (fun message -> getTextForCommand context.Me message.Text)
+    |> Option.map (fun text -> if text = command then handler context; true else false)
+    |> function 
+    | Some value -> value
+    | None -> false
 
-let cmdScan (pf : PrintfFormat<_, _, _, _, 't>) (h : 't -> unit) = 
+let cmdScan (format: PrintfFormat<_, _, _, _, 't>) (handler: 't -> unit) (context: UpdateContext) = 
     let scan command = 
-        try 
-            let r = sscanf pf command
-            Some r
+        try Some (sscanf format command)
         with _ -> None
-    
-    let f (r : Message, me : User) = 
-        match (getTextForCommand me r.Text) with
-        | Some text -> 
-            match scan text with
-            | Some p -> 
-                h p |> ignore
-                true
-            | None -> false
-        | None -> false
-    
-    f
+
+    context.Update.Message
+    |> Option.bind (fun message -> getTextForCommand context.Me message.Text)
+    |> Option.bind scan
+    |> Option.map handler
+    |> function 
+    | Some value -> true
+    | None -> false 
 
 let private runBot config me updateArrived updatesArrived = 
     let bot data = api config.Token data
@@ -97,20 +88,14 @@ let private runBot config me updateArrived updatesArrived =
     |> Async.RunSynchronously
 
 let startBot config updateArrived updatesArrived = 
-    let meResult = 
-        getMe
-        |> api config.Token
-        |> Async.RunSynchronously
-    match meResult with
-    | Error e -> failwith (e.Description)
+    getMe
+    |> api config.Token
+    |> Async.RunSynchronously
+    |> function
+    | Error error -> failwith error.Description
     | Ok me -> runBot config me updateArrived updatesArrived
-    ()
+    |> ignore
 
-let processCommands (ctx : UpdateContext) 
-    (commands : (Message * User -> bool) seq) = 
-    match ctx.Update.Message with
-    | Some msg -> 
-        commands
-        |> Seq.map (fun f -> f (msg, ctx.Me))
-        |> Seq.exists id
-    | None -> false
+let processCommands (context: UpdateContext) =
+    Seq.forall (fun command -> command context)
+    

--- a/Funogram/JsonConverters.fs
+++ b/Funogram/JsonConverters.fs
@@ -135,8 +135,7 @@ type DuConverter() =
         if isSimpleDu && reader.ValueType = typedefof<string> then 
             let name = reader.Value :?> string
             match casesTypes |> Array.tryFind (fun (_, f) -> f.Name
-                                                             |> getSnakeCaseName
-                                                             = name) with
+                                                             |> getSnakeCaseName = name) with
             | Some(u, t) -> FSharpValue.MakeUnion(u, [||])
             | None -> null
         else if reader.ValueType


### PR DESCRIPTION
For now, we handle updates from Telegram like this:
```fsharp
let update context =
  processCommands context 
    [ cmd "/hello" (fun _ -> onHello context) ]
  |> ignore
```
**cmd** function accepts `unit -> unit`.

This PR simplifies the API so we can write less code:
```fsharp
let update context =
  processCommands context
    [ cmd "/hello" onHello ]
  |> ignore
```
**cmd** function accepts `UpdateContext -> unit`. These changes are non-breaking, so the first code snippet will continue working properly after an upgrade to a newer version.