### PR TITLE
Fix UnixDateTimeConverter

### DIFF
--- a/src/Funogram.Tests/Json.fs
+++ b/src/Funogram.Tests/Json.fs
@@ -103,7 +103,7 @@ module UnixDateTimeConverterTests =
                     
     [<Theory>]
     [<ClassData(typeof<Generators.DateTimeWriteTest>)>]
-    let ``UnixDateTimeConverter WriteJson DateTime as option, nullable and just DateTime`` (data: Generators.DateTimeWriteTestValue) =
+    let ``UnixDateTimeConverter WriteJson writes DateTime as an option, and DateTime`` (data: Generators.DateTimeWriteTestValue) =
         let converter = new Funogram.JsonHelpers.UnixDateTimeConverter()
         let builder = new StringBuilder()
         converter.WriteJson(new JsonTextWriter(new StringWriter(builder)), data.Time, new JsonSerializer())
@@ -118,7 +118,7 @@ module UnixDateTimeConverterTests =
         :?> 'T
         
     [<Fact>]
-    let ``UnixDateTimeConverter ReadJson reads DateTime as option, nullable and just DateTime`` () =
+    let ``UnixDateTimeConverter ReadJson reads DateTime as an option and DateTime`` () =
         let expected = DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         let timestamp = string 946684800L
         let dateTime = readJson<DateTime> timestamp

--- a/src/Funogram.Tests/Json.fs
+++ b/src/Funogram.Tests/Json.fs
@@ -1,10 +1,5 @@
 module Funogram.Tests.Json
 
-open System
-open System.Collections
-open System.Collections.Generic
-open System.IO
-open System.Text
 open Funogram
 open Funogram.Types
 open Xunit
@@ -75,6 +70,11 @@ let ``JSON deserializing MaskPosition`` () =
     | Error error -> failwith error.Description
 
 module UnixDateTimeConverterTests =
+    open System
+    open System.Collections
+    open System.Collections.Generic
+    open System.IO
+    open System.Text
     open Newtonsoft.Json
     
     module Generators =

--- a/src/Funogram.Tests/Json.fs
+++ b/src/Funogram.Tests/Json.fs
@@ -1,5 +1,10 @@
 module Funogram.Tests.Json
 
+open System
+open System.Collections
+open System.Collections.Generic
+open System.IO
+open System.Text
 open Funogram
 open Funogram.Types
 open Xunit
@@ -68,3 +73,56 @@ let ``JSON deserializing MaskPosition`` () =
     |> function
     | Ok result -> shouldEqual result Constants.testMaskPosition
     | Error error -> failwith error.Description
+
+module UnixDateTimeConverterTests =
+    open Newtonsoft.Json
+    
+    module Generators =
+        type DateTimeWriteTestValue = {
+            Time: obj
+            UnixTime: int64
+        }
+        
+        type DateTimeWriteTest() =
+            interface IEnumerable<obj array> with
+                member __.GetEnumerator() =
+                    let time = DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                    let seconds = 946684800L
+                    let s =
+                        seq {
+                            yield { Time = box time; UnixTime = seconds }
+                            yield { Time = box (Some time); UnixTime = seconds }
+                            yield { Time = box (time.ToLocalTime()); UnixTime = seconds }
+                        }
+                        |> Seq.map (fun i -> [|box i|])
+                    s.GetEnumerator()
+                    
+            interface IEnumerable with
+                member __.GetEnumerator() =
+                    (__ :> IEnumerable<_>).GetEnumerator() :> IEnumerator
+                    
+    [<Theory>]
+    [<ClassData(typeof<Generators.DateTimeWriteTest>)>]
+    let ``UnixDateTimeConverter WriteJson DateTime as option, nullable and just DateTime`` (data: Generators.DateTimeWriteTestValue) =
+        let converter = new Funogram.JsonHelpers.UnixDateTimeConverter()
+        let builder = new StringBuilder()
+        converter.WriteJson(new JsonTextWriter(new StringWriter(builder)), data.Time, new JsonSerializer())
+        
+        shouldEqual data.UnixTime (int64 <| builder.ToString())
+        
+    let readJson<'T> value =
+        let converter = new Funogram.JsonHelpers.UnixDateTimeConverter()
+        let reader = new JsonTextReader(new StringReader(value))
+        reader.Read() |> ignore
+        converter.ReadJson(reader, typeof<'T>, value, new JsonSerializer())
+        :?> 'T
+        
+    [<Fact>]
+    let ``UnixDateTimeConverter ReadJson reads DateTime as option, nullable and just DateTime`` () =
+        let expected = DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        let timestamp = string 946684800L
+        let dateTime = readJson<DateTime> timestamp
+        let dateTimeOption = readJson<DateTime option> timestamp
+        
+        shouldEqual expected dateTime
+        shouldEqual expected (Option.get dateTimeOption)


### PR DESCRIPTION
Fix #18 

Now it will use logic simillar to [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs)