### PR TITLE
Fixed crash on empty type deserialization

### DIFF
--- a/src/Funogram.Generator/Types/TypesGenerator.fs
+++ b/src/Funogram.Generator/Types/TypesGenerator.fs
@@ -184,7 +184,7 @@ let generate config =
 
       |> (fun code ->
         match tp.Kind with
-        | Stub -> code |> Code.setIndent 1 |> Code.printNewLine "class end"
+        | Stub -> code |> Code.setIndent 1 |> Code.printNewLine "new() = {}"
         | Cases cases -> generateCasesBody cases code
         | Fields fields -> code |> generateFieldsBody tp fields |> generateFieldsCreateMember tp fields)
 

--- a/src/Funogram.Telegram/Types.fs
+++ b/src/Funogram.Telegram/Types.fs
@@ -1142,7 +1142,7 @@ and [<CLIMutable>] VideoChatScheduled =
 
 /// This object represents a service message about a video chat started in the chat. Currently holds no information.
 and VideoChatStarted =
-  class end
+  new() = {}
 
 /// This object represents a service message about a video chat ended in the chat.
 and [<CLIMutable>] VideoChatEnded =
@@ -4370,7 +4370,7 @@ and [<CLIMutable>] Game =
 
 /// A placeholder, currently holds no information. Use BotFather to set up your game.
 and CallbackGame =
-  class end
+  new() = {}
 
 /// This object represents one row of the high scores table for a game.
 /// And that's about all we've got for now.


### PR DESCRIPTION
I get the error "ApiResponseException: generated serializer for CallbackGame does not support deserialize" on mini-game message sending (@gamebot). unsure exactly how this fix works, but utf8json stopped crashing.