### PR TITLE
Bugfix/broken escaping

### DIFF
--- a/src/Funogram.Tests/Deserializer.fs
+++ b/src/Funogram.Tests/Deserializer.fs
@@ -61,5 +61,11 @@ let ``Deserializer should work``(): unit =
 }"""
     let input = Encoding.UTF8.GetBytes brokenUpdate
     use stream = new MemoryStream(input)
-    let result = Tools.parseJsonStreamApiResponse<Update[]> stream
-    Assert.True(Result.isOk result)
+    match Tools.parseJsonStreamApiResponse<Update[]> stream with
+    | Error e -> Assert.True(false, e.ToString())
+    | Ok result ->
+
+    let update = Assert.Single result
+    match update.Message with
+    | None -> Assert.True(false, "No message")
+    | Some message -> Assert.Equal(1L, message.MessageId)

--- a/src/Funogram.Tests/Deserializer.fs
+++ b/src/Funogram.Tests/Deserializer.fs
@@ -1,0 +1,65 @@
+﻿module Funogram.Tests.Deserializer
+
+open System.IO
+open System.Text
+
+open Xunit
+
+open Funogram
+open Funogram.Telegram.Types
+
+[<Fact>]
+let ``Deserializer should work``(): unit =
+    let brokenUpdate = """{
+    "ok": true,
+    "result": [
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 1,
+                "from": {
+                    "id": 1,
+                    "is_bot": false,
+                    "first_name": "1",
+                    "last_name": "1",
+                    "username": "1"
+                },
+                "chat": {
+                    "id": -1,
+                    "title": "1",
+                    "username": "1",
+                    "type": "supergroup"
+                },
+                "date": 1707128434,
+                "message_thread_id": 1,
+                "reply_to_message": {
+                    "message_id": 1,
+                    "from": {
+                        "id": 1,
+                        "is_bot": false,
+                        "first_name": "2",
+                        "username": "2",
+                        "is_premium": true
+                    },
+                    "chat": {
+                        "id": -1,
+                        "title": "1",
+                        "username": "1",
+                        "type": "supergroup"
+                    },
+                    "date": 1707117257,
+                    "message_thread_id": 1,
+                    "quote": {
+                        "text": "Ins\\",
+                        "position": 9,
+                        "is_manual": true
+                    }
+                }
+            }
+        }
+    ]
+}"""
+    let input = Encoding.UTF8.GetBytes brokenUpdate
+    use stream = new MemoryStream(input)
+    let result = Tools.parseJsonStreamApiResponse<Update[]> stream
+    Assert.True(Result.isOk result)

--- a/src/Funogram.Tests/Funogram.Tests.fsproj
+++ b/src/Funogram.Tests/Funogram.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Extensions.fs" />
     <Compile Include="Json.fs" />
     <Compile Include="Core.fs" />
+    <Compile Include="Deserializer.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION
This adds a test I created while investigating https://github.com/codingteam/emulsion/issues/190.

To summarize: there are no known DoS issues with the latest version of Funogram.

We should consider migrating away from Utf8Json, though, and this test may serve as one of the checks we'll perform before migration to another JSON library.