### PR TITLE
Fix DU case selection for tag-discriminated unions (ChatMember et al.)

### DIFF
--- a/src/Funogram.Generator/Types/TypesGenerator.fs
+++ b/src/Funogram.Generator/Types/TypesGenerator.fs
@@ -163,9 +163,29 @@ let private generateFieldsCreateMember tp (fields: ApiTypeField[]) code =
   |> Code.setIndent 2
   |> Code.printNewLine "}"
 
+// Subtypes of tag-discriminated unions (ChatMember, MessageOrigin, ReactionType, ...)
+// document their fixed discriminator as `always "X"` on a required string field.
+// Emit it as a TelegramTag attribute so the union converter can select the case by
+// the discriminator value (shape-identical subtypes like ChatMemberLeft vs
+// ChatMemberMember cannot be discriminated any other way).
+let private discriminatorRegex =
+  System.Text.RegularExpressions.Regex("""always [“"]([A-Za-z0-9_]+)[”"]""",
+                                       System.Text.RegularExpressions.RegexOptions.Compiled)
+
+let private discriminatorTag (fields: ApiTypeField[]) =
+  fields
+  |> Array.tryPick (fun f ->
+    if f.IsOptional || f.ConvertedFieldType <> "string" then None
+    else
+      let m = discriminatorRegex.Match f.Description
+      if m.Success then Some (f.OriginalName, m.Groups[1].Value) else None)
+
 let private attributesForType tp =
   match tp.Kind with
-  | ApiTypeKind.Fields _ -> " [<CLIMutable>]"
+  | ApiTypeKind.Fields fields ->
+    match discriminatorTag fields with
+    | Some (field, value) -> sprintf " [<CLIMutable; Funogram.Types.TelegramTag(\"%s\", \"%s\")>]" field value
+    | None -> " [<CLIMutable>]"
   | _ -> ""
 
 let generate config =

--- a/src/Funogram.Telegram/Types.fs
+++ b/src/Funogram.Telegram/Types.fs
@@ -1305,7 +1305,7 @@ and MessageOrigin =
   | Channel of MessageOriginChannel
 
 /// The message was originally sent by a known user.
-and [<CLIMutable>] MessageOriginUser =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "user")>] MessageOriginUser =
   {
     /// Type of the message origin, always “user”
     [<DataMember(Name = "type")>]
@@ -1325,7 +1325,7 @@ and [<CLIMutable>] MessageOriginUser =
     }
 
 /// The message was originally sent by an unknown user.
-and [<CLIMutable>] MessageOriginHiddenUser =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "hidden_user")>] MessageOriginHiddenUser =
   {
     /// Type of the message origin, always “hidden_user”
     [<DataMember(Name = "type")>]
@@ -1345,7 +1345,7 @@ and [<CLIMutable>] MessageOriginHiddenUser =
     }
 
 /// The message was originally sent on behalf of a chat to a group chat.
-and [<CLIMutable>] MessageOriginChat =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "chat")>] MessageOriginChat =
   {
     /// Type of the message origin, always “chat”
     [<DataMember(Name = "type")>]
@@ -1369,7 +1369,7 @@ and [<CLIMutable>] MessageOriginChat =
     }
 
 /// The message was originally sent to a channel chat.
-and [<CLIMutable>] MessageOriginChannel =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "channel")>] MessageOriginChannel =
   {
     /// Type of the message origin, always “channel”
     [<DataMember(Name = "type")>]
@@ -1772,7 +1772,7 @@ and PaidMedia =
   | Video of PaidMediaVideo
 
 /// The paid media is a live photo.
-and [<CLIMutable>] PaidMediaLivePhoto =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "live_photo")>] PaidMediaLivePhoto =
   {
     /// Type of the paid media, always “live_photo”
     [<DataMember(Name = "type")>]
@@ -1788,7 +1788,7 @@ and [<CLIMutable>] PaidMediaLivePhoto =
     }
 
 /// The paid media is a photo.
-and [<CLIMutable>] PaidMediaPhoto =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "photo")>] PaidMediaPhoto =
   {
     /// Type of the paid media, always “photo”
     [<DataMember(Name = "type")>]
@@ -1804,7 +1804,7 @@ and [<CLIMutable>] PaidMediaPhoto =
     }
 
 /// The paid media isn't available before the payment.
-and [<CLIMutable>] PaidMediaPreview =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "preview")>] PaidMediaPreview =
   {
     /// Type of the paid media, always “preview”
     [<DataMember(Name = "type")>]
@@ -1828,7 +1828,7 @@ and [<CLIMutable>] PaidMediaPreview =
     }
 
 /// The paid media is a video.
-and [<CLIMutable>] PaidMediaVideo =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "video")>] PaidMediaVideo =
   {
     /// Type of the paid media, always “video”
     [<DataMember(Name = "type")>]
@@ -2516,7 +2516,7 @@ and BackgroundFill =
   | FreeformGradient of BackgroundFillFreeformGradient
 
 /// The background is filled using the selected color.
-and [<CLIMutable>] BackgroundFillSolid =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "solid")>] BackgroundFillSolid =
   {
     /// Type of the background fill, always “solid”
     [<DataMember(Name = "type")>]
@@ -2532,7 +2532,7 @@ and [<CLIMutable>] BackgroundFillSolid =
     }
 
 /// The background is a gradient fill.
-and [<CLIMutable>] BackgroundFillGradient =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "gradient")>] BackgroundFillGradient =
   {
     /// Type of the background fill, always “gradient”
     [<DataMember(Name = "type")>]
@@ -2556,7 +2556,7 @@ and [<CLIMutable>] BackgroundFillGradient =
     }
 
 /// The background is a freeform gradient that rotates after every message in the chat.
-and [<CLIMutable>] BackgroundFillFreeformGradient =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "freeform_gradient")>] BackgroundFillFreeformGradient =
   {
     /// Type of the background fill, always “freeform_gradient”
     [<DataMember(Name = "type")>]
@@ -2579,7 +2579,7 @@ and BackgroundType =
   | ChatTheme of BackgroundTypeChatTheme
 
 /// The background is automatically filled based on the selected colors.
-and [<CLIMutable>] BackgroundTypeFill =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "fill")>] BackgroundTypeFill =
   {
     /// Type of the background, always “fill”
     [<DataMember(Name = "type")>]
@@ -2599,7 +2599,7 @@ and [<CLIMutable>] BackgroundTypeFill =
     }
 
 /// The background is a wallpaper in the JPEG format.
-and [<CLIMutable>] BackgroundTypeWallpaper =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "wallpaper")>] BackgroundTypeWallpaper =
   {
     /// Type of the background, always “wallpaper”
     [<DataMember(Name = "type")>]
@@ -2627,7 +2627,7 @@ and [<CLIMutable>] BackgroundTypeWallpaper =
     }
 
 /// The background is a .PNG or .TGV (gzipped subset of SVG with MIME type “application/x-tgwallpattern”) pattern to be combined with the background fill chosen by the user.
-and [<CLIMutable>] BackgroundTypePattern =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "pattern")>] BackgroundTypePattern =
   {
     /// Type of the background, always “pattern”
     [<DataMember(Name = "type")>]
@@ -2659,7 +2659,7 @@ and [<CLIMutable>] BackgroundTypePattern =
     }
 
 /// The background is taken directly from a built-in chat theme.
-and [<CLIMutable>] BackgroundTypeChatTheme =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "chat_theme")>] BackgroundTypeChatTheme =
   {
     /// Type of the background, always “chat_theme”
     [<DataMember(Name = "type")>]
@@ -3933,7 +3933,7 @@ and ChatMember =
   | Banned of ChatMemberBanned
 
 /// Represents a chat member that owns the chat and has all administrator privileges.
-and [<CLIMutable>] ChatMemberOwner =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "creator")>] ChatMemberOwner =
   {
     /// The member's status in the chat, always “creator”
     [<DataMember(Name = "status")>]
@@ -3957,7 +3957,7 @@ and [<CLIMutable>] ChatMemberOwner =
     }
 
 /// Represents a chat member that has some additional privileges.
-and [<CLIMutable>] ChatMemberAdministrator =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "administrator")>] ChatMemberAdministrator =
   {
     /// The member's status in the chat, always “administrator”
     [<DataMember(Name = "status")>]
@@ -4053,7 +4053,7 @@ and [<CLIMutable>] ChatMemberAdministrator =
     }
 
 /// Represents a chat member that has no additional privileges or restrictions.
-and [<CLIMutable>] ChatMemberMember =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "member")>] ChatMemberMember =
   {
     /// The member's status in the chat, always “member”
     [<DataMember(Name = "status")>]
@@ -4077,7 +4077,7 @@ and [<CLIMutable>] ChatMemberMember =
     }
 
 /// Represents a chat member that is under certain restrictions in the chat. Supergroups only.
-and [<CLIMutable>] ChatMemberRestricted =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "restricted")>] ChatMemberRestricted =
   {
     /// The member's status in the chat, always “restricted”
     [<DataMember(Name = "status")>]
@@ -4169,7 +4169,7 @@ and [<CLIMutable>] ChatMemberRestricted =
     }
 
 /// Represents a chat member that isn't currently a member of the chat, but may join it themselves.
-and [<CLIMutable>] ChatMemberLeft =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "left")>] ChatMemberLeft =
   {
     /// The member's status in the chat, always “left”
     [<DataMember(Name = "status")>]
@@ -4185,7 +4185,7 @@ and [<CLIMutable>] ChatMemberLeft =
     }
 
 /// Represents a chat member that was banned in the chat and can't return to the chat or view chat messages.
-and [<CLIMutable>] ChatMemberBanned =
+and [<CLIMutable; Funogram.Types.TelegramTag("status", "kicked")>] ChatMemberBanned =
   {
     /// The member's status in the chat, always “kicked”
     [<DataMember(Name = "status")>]
@@ -4489,7 +4489,7 @@ and StoryAreaType =
   | UniqueGift of StoryAreaTypeUniqueGift
 
 /// Describes a story area pointing to a location. Currently, a story can have up to 10 location areas.
-and [<CLIMutable>] StoryAreaTypeLocation =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "location")>] StoryAreaTypeLocation =
   {
     /// Type of the area, always “location”
     [<DataMember(Name = "type")>]
@@ -4513,7 +4513,7 @@ and [<CLIMutable>] StoryAreaTypeLocation =
     }
 
 /// Describes a story area pointing to a suggested reaction. Currently, a story can have up to 5 suggested reaction areas.
-and [<CLIMutable>] StoryAreaTypeSuggestedReaction =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "suggested_reaction")>] StoryAreaTypeSuggestedReaction =
   {
     /// Type of the area, always “suggested_reaction”
     [<DataMember(Name = "type")>]
@@ -4537,7 +4537,7 @@ and [<CLIMutable>] StoryAreaTypeSuggestedReaction =
     }
 
 /// Describes a story area pointing to an HTTP or tg:// link. Currently, a story can have up to 3 link areas.
-and [<CLIMutable>] StoryAreaTypeLink =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "link")>] StoryAreaTypeLink =
   {
     /// Type of the area, always “link”
     [<DataMember(Name = "type")>]
@@ -4553,7 +4553,7 @@ and [<CLIMutable>] StoryAreaTypeLink =
     }
 
 /// Describes a story area containing weather information. Currently, a story can have up to 3 weather areas.
-and [<CLIMutable>] StoryAreaTypeWeather =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "weather")>] StoryAreaTypeWeather =
   {
     /// Type of the area, always “weather”
     [<DataMember(Name = "type")>]
@@ -4577,7 +4577,7 @@ and [<CLIMutable>] StoryAreaTypeWeather =
     }
 
 /// Describes a story area pointing to a unique gift. Currently, a story can have at most 1 unique gift area.
-and [<CLIMutable>] StoryAreaTypeUniqueGift =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "unique_gift")>] StoryAreaTypeUniqueGift =
   {
     /// Type of the area, always “unique_gift”
     [<DataMember(Name = "type")>]
@@ -4631,7 +4631,7 @@ and ReactionType =
   | Paid of ReactionTypePaid
 
 /// The reaction is based on an emoji.
-and [<CLIMutable>] ReactionTypeEmoji =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "emoji")>] ReactionTypeEmoji =
   {
     /// Type of the reaction, always “emoji”
     [<DataMember(Name = "type")>]
@@ -4647,7 +4647,7 @@ and [<CLIMutable>] ReactionTypeEmoji =
     }
 
 /// The reaction is based on a custom emoji.
-and [<CLIMutable>] ReactionTypeCustomEmoji =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "custom_emoji")>] ReactionTypeCustomEmoji =
   {
     /// Type of the reaction, always “custom_emoji”
     [<DataMember(Name = "type")>]
@@ -4663,7 +4663,7 @@ and [<CLIMutable>] ReactionTypeCustomEmoji =
     }
 
 /// The reaction is paid.
-and [<CLIMutable>] ReactionTypePaid =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "paid")>] ReactionTypePaid =
   {
     /// Type of the reaction, always “paid”
     [<DataMember(Name = "type")>]
@@ -5136,7 +5136,7 @@ and OwnedGift =
   | Unique of OwnedGiftUnique
 
 /// Describes a regular gift owned by a user or a chat.
-and [<CLIMutable>] OwnedGiftRegular =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "regular")>] OwnedGiftRegular =
   {
     /// Type of the gift, always “regular”
     [<DataMember(Name = "type")>]
@@ -5204,7 +5204,7 @@ and [<CLIMutable>] OwnedGiftRegular =
     }
 
 /// Describes a unique gift received and owned by a user or a chat.
-and [<CLIMutable>] OwnedGiftUnique =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "unique")>] OwnedGiftUnique =
   {
     /// Type of the gift, always “unique”
     [<DataMember(Name = "type")>]
@@ -5547,7 +5547,7 @@ and ChatBoostSource =
   | Giveaway of ChatBoostSourceGiveaway
 
 /// The boost was obtained by subscribing to Telegram Premium or by gifting a Telegram Premium subscription to another user.
-and [<CLIMutable>] ChatBoostSourcePremium =
+and [<CLIMutable; Funogram.Types.TelegramTag("source", "premium")>] ChatBoostSourcePremium =
   {
     /// Source of the boost, always “premium”
     [<DataMember(Name = "source")>]
@@ -5563,7 +5563,7 @@ and [<CLIMutable>] ChatBoostSourcePremium =
     }
 
 /// The boost was obtained by the creation of Telegram Premium gift codes to boost a chat. Each such code boosts the chat 4 times for the duration of the corresponding Telegram Premium subscription.
-and [<CLIMutable>] ChatBoostSourceGiftCode =
+and [<CLIMutable; Funogram.Types.TelegramTag("source", "gift_code")>] ChatBoostSourceGiftCode =
   {
     /// Source of the boost, always “gift_code”
     [<DataMember(Name = "source")>]
@@ -5579,7 +5579,7 @@ and [<CLIMutable>] ChatBoostSourceGiftCode =
     }
 
 /// The boost was obtained by the creation of a Telegram Premium or a Telegram Star giveaway. This boosts the chat 4 times for the duration of the corresponding Telegram Premium subscription for Telegram Premium giveaways and prize_star_count / 500 times for one year for Telegram Star giveaways.
-and [<CLIMutable>] ChatBoostSourceGiveaway =
+and [<CLIMutable; Funogram.Types.TelegramTag("source", "giveaway")>] ChatBoostSourceGiveaway =
   {
     /// Source of the boost, always “giveaway”
     [<DataMember(Name = "source")>]
@@ -6670,7 +6670,7 @@ and RichText =
   | ArrayOf of RichText array
 
 /// A bold text.
-and [<CLIMutable>] RichTextBold =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "bold")>] RichTextBold =
   {
     /// Type of the rich text, always “bold”
     [<DataMember(Name = "type")>]
@@ -6686,7 +6686,7 @@ and [<CLIMutable>] RichTextBold =
     }
 
 /// An italicized text.
-and [<CLIMutable>] RichTextItalic =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "italic")>] RichTextItalic =
   {
     /// Type of the rich text, always “italic”
     [<DataMember(Name = "type")>]
@@ -6702,7 +6702,7 @@ and [<CLIMutable>] RichTextItalic =
     }
 
 /// An underlined text.
-and [<CLIMutable>] RichTextUnderline =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "underline")>] RichTextUnderline =
   {
     /// Type of the rich text, always “underline”
     [<DataMember(Name = "type")>]
@@ -6718,7 +6718,7 @@ and [<CLIMutable>] RichTextUnderline =
     }
 
 /// A strikethrough text.
-and [<CLIMutable>] RichTextStrikethrough =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "strikethrough")>] RichTextStrikethrough =
   {
     /// Type of the rich text, always “strikethrough”
     [<DataMember(Name = "type")>]
@@ -6734,7 +6734,7 @@ and [<CLIMutable>] RichTextStrikethrough =
     }
 
 /// A text covered by a spoiler.
-and [<CLIMutable>] RichTextSpoiler =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "spoiler")>] RichTextSpoiler =
   {
     /// Type of the rich text, always “spoiler”
     [<DataMember(Name = "type")>]
@@ -6750,7 +6750,7 @@ and [<CLIMutable>] RichTextSpoiler =
     }
 
 /// Formatted date and time.
-and [<CLIMutable>] RichTextDateTime =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "date_time")>] RichTextDateTime =
   {
     /// Type of the rich text, always “date_time”
     [<DataMember(Name = "type")>]
@@ -6774,7 +6774,7 @@ and [<CLIMutable>] RichTextDateTime =
     }
 
 /// A mention of a Telegram user by their identifier.
-and [<CLIMutable>] RichTextTextMention =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "text_mention")>] RichTextTextMention =
   {
     /// Type of the rich text, always “text_mention”
     [<DataMember(Name = "type")>]
@@ -6794,7 +6794,7 @@ and [<CLIMutable>] RichTextTextMention =
     }
 
 /// A subscript text.
-and [<CLIMutable>] RichTextSubscript =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "subscript")>] RichTextSubscript =
   {
     /// Type of the rich text, always “subscript”
     [<DataMember(Name = "type")>]
@@ -6810,7 +6810,7 @@ and [<CLIMutable>] RichTextSubscript =
     }
 
 /// A superscript text.
-and [<CLIMutable>] RichTextSuperscript =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "superscript")>] RichTextSuperscript =
   {
     /// Type of the rich text, always “superscript”
     [<DataMember(Name = "type")>]
@@ -6826,7 +6826,7 @@ and [<CLIMutable>] RichTextSuperscript =
     }
 
 /// A marked text.
-and [<CLIMutable>] RichTextMarked =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "marked")>] RichTextMarked =
   {
     /// Type of the rich text, always “marked”
     [<DataMember(Name = "type")>]
@@ -6842,7 +6842,7 @@ and [<CLIMutable>] RichTextMarked =
     }
 
 /// A monowidth text.
-and [<CLIMutable>] RichTextCode =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "code")>] RichTextCode =
   {
     /// Type of the rich text, always “code”
     [<DataMember(Name = "type")>]
@@ -6858,7 +6858,7 @@ and [<CLIMutable>] RichTextCode =
     }
 
 /// A custom emoji.
-and [<CLIMutable>] RichTextCustomEmoji =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "custom_emoji")>] RichTextCustomEmoji =
   {
     /// Type of the rich text, always “custom_emoji”
     [<DataMember(Name = "type")>]
@@ -6878,7 +6878,7 @@ and [<CLIMutable>] RichTextCustomEmoji =
     }
 
 /// A mathematical expression.
-and [<CLIMutable>] RichTextMathematicalExpression =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "mathematical_expression")>] RichTextMathematicalExpression =
   {
     /// Type of the rich text, always “mathematical_expression”
     [<DataMember(Name = "type")>]
@@ -6894,7 +6894,7 @@ and [<CLIMutable>] RichTextMathematicalExpression =
     }
 
 /// A text with a link.
-and [<CLIMutable>] RichTextUrl =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "url")>] RichTextUrl =
   {
     /// Type of the rich text, always “url”
     [<DataMember(Name = "type")>]
@@ -6914,7 +6914,7 @@ and [<CLIMutable>] RichTextUrl =
     }
 
 /// A text with an email address.
-and [<CLIMutable>] RichTextEmailAddress =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "email_address")>] RichTextEmailAddress =
   {
     /// Type of the rich text, always “email_address”
     [<DataMember(Name = "type")>]
@@ -6934,7 +6934,7 @@ and [<CLIMutable>] RichTextEmailAddress =
     }
 
 /// A text with a phone number.
-and [<CLIMutable>] RichTextPhoneNumber =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "phone_number")>] RichTextPhoneNumber =
   {
     /// Type of the rich text, always “phone_number”
     [<DataMember(Name = "type")>]
@@ -6954,7 +6954,7 @@ and [<CLIMutable>] RichTextPhoneNumber =
     }
 
 /// A text with a bank card number.
-and [<CLIMutable>] RichTextBankCardNumber =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "bank_card_number")>] RichTextBankCardNumber =
   {
     /// Type of the rich text, always “bank_card_number”
     [<DataMember(Name = "type")>]
@@ -6974,7 +6974,7 @@ and [<CLIMutable>] RichTextBankCardNumber =
     }
 
 /// A mention by a username.
-and [<CLIMutable>] RichTextMention =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "mention")>] RichTextMention =
   {
     /// Type of the rich text, always “mention”
     [<DataMember(Name = "type")>]
@@ -6994,7 +6994,7 @@ and [<CLIMutable>] RichTextMention =
     }
 
 /// A hashtag.
-and [<CLIMutable>] RichTextHashtag =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "hashtag")>] RichTextHashtag =
   {
     /// Type of the rich text, always “hashtag”
     [<DataMember(Name = "type")>]
@@ -7014,7 +7014,7 @@ and [<CLIMutable>] RichTextHashtag =
     }
 
 /// A cashtag.
-and [<CLIMutable>] RichTextCashtag =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "cashtag")>] RichTextCashtag =
   {
     /// Type of the rich text, always “cashtag”
     [<DataMember(Name = "type")>]
@@ -7034,7 +7034,7 @@ and [<CLIMutable>] RichTextCashtag =
     }
 
 /// A bot command.
-and [<CLIMutable>] RichTextBotCommand =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "bot_command")>] RichTextBotCommand =
   {
     /// Type of the rich text, always “bot_command”
     [<DataMember(Name = "type")>]
@@ -7054,7 +7054,7 @@ and [<CLIMutable>] RichTextBotCommand =
     }
 
 /// An anchor.
-and [<CLIMutable>] RichTextAnchor =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "anchor")>] RichTextAnchor =
   {
     /// Type of the rich text, always “anchor”
     [<DataMember(Name = "type")>]
@@ -7070,7 +7070,7 @@ and [<CLIMutable>] RichTextAnchor =
     }
 
 /// A link to an anchor.
-and [<CLIMutable>] RichTextAnchorLink =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "anchor_link")>] RichTextAnchorLink =
   {
     /// Type of the rich text, always “anchor_link”
     [<DataMember(Name = "type")>]
@@ -7090,7 +7090,7 @@ and [<CLIMutable>] RichTextAnchorLink =
     }
 
 /// A reference.
-and [<CLIMutable>] RichTextReference =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "reference")>] RichTextReference =
   {
     /// Type of the rich text, always “reference”
     [<DataMember(Name = "type")>]
@@ -7110,7 +7110,7 @@ and [<CLIMutable>] RichTextReference =
     }
 
 /// A link to a reference.
-and [<CLIMutable>] RichTextReferenceLink =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "reference_link")>] RichTextReferenceLink =
   {
     /// Type of the rich text, always “reference_link”
     [<DataMember(Name = "type")>]
@@ -7234,7 +7234,7 @@ and RichBlock =
   | Thinking of RichBlockThinking
 
 /// A text paragraph, corresponding to the HTML tag <p>.
-and [<CLIMutable>] RichBlockParagraph =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "paragraph")>] RichBlockParagraph =
   {
     /// Type of the block, always “paragraph”
     [<DataMember(Name = "type")>]
@@ -7250,7 +7250,7 @@ and [<CLIMutable>] RichBlockParagraph =
     }
 
 /// A section heading, corresponding to the HTML tags <h1>, <h2>, <h3>, <h4>, <h5>, or <h6>.
-and [<CLIMutable>] RichBlockSectionHeading =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "heading")>] RichBlockSectionHeading =
   {
     /// Type of the block, always “heading”
     [<DataMember(Name = "type")>]
@@ -7270,7 +7270,7 @@ and [<CLIMutable>] RichBlockSectionHeading =
     }
 
 /// A preformatted text block, corresponding to the nested HTML tags <pre> and <code>.
-and [<CLIMutable>] RichBlockPreformatted =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "pre")>] RichBlockPreformatted =
   {
     /// Type of the block, always “pre”
     [<DataMember(Name = "type")>]
@@ -7290,7 +7290,7 @@ and [<CLIMutable>] RichBlockPreformatted =
     }
 
 /// A footer, corresponding to the HTML tag <footer>.
-and [<CLIMutable>] RichBlockFooter =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "footer")>] RichBlockFooter =
   {
     /// Type of the block, always “footer”
     [<DataMember(Name = "type")>]
@@ -7306,7 +7306,7 @@ and [<CLIMutable>] RichBlockFooter =
     }
 
 /// A divider, corresponding to the HTML tag <hr/>.
-and [<CLIMutable>] RichBlockDivider =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "divider")>] RichBlockDivider =
   {
     /// Type of the block, always “divider”
     [<DataMember(Name = "type")>]
@@ -7318,7 +7318,7 @@ and [<CLIMutable>] RichBlockDivider =
     }
 
 /// A block with a mathematical expression in LaTeX format, corresponding to the custom HTML tag <tg-math-block>.
-and [<CLIMutable>] RichBlockMathematicalExpression =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "mathematical_expression")>] RichBlockMathematicalExpression =
   {
     /// Type of the block, always “mathematical_expression”
     [<DataMember(Name = "type")>]
@@ -7334,7 +7334,7 @@ and [<CLIMutable>] RichBlockMathematicalExpression =
     }
 
 /// A block with an anchor, corresponding to the HTML tag <a> with the attribute name.
-and [<CLIMutable>] RichBlockAnchor =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "anchor")>] RichBlockAnchor =
   {
     /// Type of the block, always “anchor”
     [<DataMember(Name = "type")>]
@@ -7350,7 +7350,7 @@ and [<CLIMutable>] RichBlockAnchor =
     }
 
 /// A list of blocks, corresponding to the HTML tag <ul> or <ol> with multiple nested tags <li>.
-and [<CLIMutable>] RichBlockList =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "list")>] RichBlockList =
   {
     /// Type of the block, always “list”
     [<DataMember(Name = "type")>]
@@ -7366,7 +7366,7 @@ and [<CLIMutable>] RichBlockList =
     }
 
 /// A block quotation, corresponding to the HTML tag <blockquote>.
-and [<CLIMutable>] RichBlockBlockQuotation =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "blockquote")>] RichBlockBlockQuotation =
   {
     /// Type of the block, always “blockquote”
     [<DataMember(Name = "type")>]
@@ -7386,7 +7386,7 @@ and [<CLIMutable>] RichBlockBlockQuotation =
     }
 
 /// A quotation with centered text, loosely corresponding to the HTML tag <aside>.
-and [<CLIMutable>] RichBlockPullQuotation =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "pullquote")>] RichBlockPullQuotation =
   {
     /// Type of the block, always “pullquote”
     [<DataMember(Name = "type")>]
@@ -7406,7 +7406,7 @@ and [<CLIMutable>] RichBlockPullQuotation =
     }
 
 /// A collage, corresponding to the custom HTML tag <tg-collage>.
-and [<CLIMutable>] RichBlockCollage =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "collage")>] RichBlockCollage =
   {
     /// Type of the block, always “collage”
     [<DataMember(Name = "type")>]
@@ -7426,7 +7426,7 @@ and [<CLIMutable>] RichBlockCollage =
     }
 
 /// A slideshow, corresponding to the custom HTML tag <tg-slideshow>.
-and [<CLIMutable>] RichBlockSlideshow =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "slideshow")>] RichBlockSlideshow =
   {
     /// Type of the block, always “slideshow”
     [<DataMember(Name = "type")>]
@@ -7446,7 +7446,7 @@ and [<CLIMutable>] RichBlockSlideshow =
     }
 
 /// A table, corresponding to the HTML tag <table>.
-and [<CLIMutable>] RichBlockTable =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "table")>] RichBlockTable =
   {
     /// Type of the block, always “table”
     [<DataMember(Name = "type")>]
@@ -7474,7 +7474,7 @@ and [<CLIMutable>] RichBlockTable =
     }
 
 /// An expandable block for details disclosure, corresponding to the HTML tag <details>.
-and [<CLIMutable>] RichBlockDetails =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "details")>] RichBlockDetails =
   {
     /// Type of the block, always “details”
     [<DataMember(Name = "type")>]
@@ -7498,7 +7498,7 @@ and [<CLIMutable>] RichBlockDetails =
     }
 
 /// A block with a map, corresponding to the custom HTML tag <tg-map>.
-and [<CLIMutable>] RichBlockMap =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "map")>] RichBlockMap =
   {
     /// Type of the block, always “map”
     [<DataMember(Name = "type")>]
@@ -7530,7 +7530,7 @@ and [<CLIMutable>] RichBlockMap =
     }
 
 /// A block with an animation, corresponding to the HTML tag <video>.
-and [<CLIMutable>] RichBlockAnimation =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "animation")>] RichBlockAnimation =
   {
     /// Type of the block, always “animation”
     [<DataMember(Name = "type")>]
@@ -7554,7 +7554,7 @@ and [<CLIMutable>] RichBlockAnimation =
     }
 
 /// A block with a music file, corresponding to the HTML tag <audio>.
-and [<CLIMutable>] RichBlockAudio =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "audio")>] RichBlockAudio =
   {
     /// Type of the block, always “audio”
     [<DataMember(Name = "type")>]
@@ -7574,7 +7574,7 @@ and [<CLIMutable>] RichBlockAudio =
     }
 
 /// A block with a photo, corresponding to the HTML tag <photo>.
-and [<CLIMutable>] RichBlockPhoto =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "photo")>] RichBlockPhoto =
   {
     /// Type of the block, always “photo”
     [<DataMember(Name = "type")>]
@@ -7598,7 +7598,7 @@ and [<CLIMutable>] RichBlockPhoto =
     }
 
 /// A block with a video, corresponding to the HTML tag <video>.
-and [<CLIMutable>] RichBlockVideo =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "video")>] RichBlockVideo =
   {
     /// Type of the block, always “video”
     [<DataMember(Name = "type")>]
@@ -7622,7 +7622,7 @@ and [<CLIMutable>] RichBlockVideo =
     }
 
 /// A block with a voice note, corresponding to the HTML tag <audio>.
-and [<CLIMutable>] RichBlockVoiceNote =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "voice_note")>] RichBlockVoiceNote =
   {
     /// Type of the block, always “voice_note”
     [<DataMember(Name = "type")>]
@@ -7645,7 +7645,7 @@ and [<CLIMutable>] RichBlockVoiceNote =
 /// The following methods and objects allow your bot to work in inline mode.
 /// Please see our Introduction to Inline bots for more details.
 /// To enable this option, send the /setinline command to @BotFather and provide the placeholder text that the user will see in the input field after typing your bot's name.
-and [<CLIMutable>] RichBlockThinking =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "thinking")>] RichBlockThinking =
   {
     /// Type of the block, always “thinking”
     [<DataMember(Name = "type")>]
@@ -9218,7 +9218,7 @@ and [<CLIMutable>] SuccessfulPayment =
     }
 
 /// This object contains basic information about a refunded payment.
-and [<CLIMutable>] RefundedPayment =
+and [<CLIMutable; Funogram.Types.TelegramTag("currency", "XTR")>] RefundedPayment =
   {
     /// Three-letter ISO 4217 currency code, or “XTR” for payments in Telegram Stars. Currently, always “XTR”.
     [<DataMember(Name = "currency")>]
@@ -9328,7 +9328,7 @@ and RevenueWithdrawalState =
   | Failed of RevenueWithdrawalStateFailed
 
 /// The withdrawal is in progress.
-and [<CLIMutable>] RevenueWithdrawalStatePending =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "pending")>] RevenueWithdrawalStatePending =
   {
     /// Type of the state, always “pending”
     [<DataMember(Name = "type")>]
@@ -9340,7 +9340,7 @@ and [<CLIMutable>] RevenueWithdrawalStatePending =
     }
 
 /// The withdrawal succeeded.
-and [<CLIMutable>] RevenueWithdrawalStateSucceeded =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "succeeded")>] RevenueWithdrawalStateSucceeded =
   {
     /// Type of the state, always “succeeded”
     [<DataMember(Name = "type")>]
@@ -9360,7 +9360,7 @@ and [<CLIMutable>] RevenueWithdrawalStateSucceeded =
     }
 
 /// The withdrawal failed and the transaction was refunded.
-and [<CLIMutable>] RevenueWithdrawalStateFailed =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "failed")>] RevenueWithdrawalStateFailed =
   {
     /// Type of the state, always “failed”
     [<DataMember(Name = "type")>]
@@ -9410,7 +9410,7 @@ and TransactionPartner =
   | Other of TransactionPartnerOther
 
 /// Describes a transaction with a user.
-and [<CLIMutable>] TransactionPartnerUser =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "user")>] TransactionPartnerUser =
   {
     /// Type of the transaction partner, always “user”
     [<DataMember(Name = "type")>]
@@ -9458,7 +9458,7 @@ and [<CLIMutable>] TransactionPartnerUser =
     }
 
 /// Describes a transaction with a chat.
-and [<CLIMutable>] TransactionPartnerChat =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "chat")>] TransactionPartnerChat =
   {
     /// Type of the transaction partner, always “chat”
     [<DataMember(Name = "type")>]
@@ -9478,7 +9478,7 @@ and [<CLIMutable>] TransactionPartnerChat =
     }
 
 /// Describes the affiliate program that issued the affiliate commission received via this transaction.
-and [<CLIMutable>] TransactionPartnerAffiliateProgram =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "affiliate_program")>] TransactionPartnerAffiliateProgram =
   {
     /// Type of the transaction partner, always “affiliate_program”
     [<DataMember(Name = "type")>]
@@ -9498,7 +9498,7 @@ and [<CLIMutable>] TransactionPartnerAffiliateProgram =
     }
 
 /// Describes a withdrawal transaction with Fragment.
-and [<CLIMutable>] TransactionPartnerFragment =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "fragment")>] TransactionPartnerFragment =
   {
     /// Type of the transaction partner, always “fragment”
     [<DataMember(Name = "type")>]
@@ -9514,7 +9514,7 @@ and [<CLIMutable>] TransactionPartnerFragment =
     }
 
 /// Describes a withdrawal transaction to the Telegram Ads platform.
-and [<CLIMutable>] TransactionPartnerTelegramAds =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "telegram_ads")>] TransactionPartnerTelegramAds =
   {
     /// Type of the transaction partner, always “telegram_ads”
     [<DataMember(Name = "type")>]
@@ -9526,7 +9526,7 @@ and [<CLIMutable>] TransactionPartnerTelegramAds =
     }
 
 /// Describes a transaction with payment for paid broadcasting.
-and [<CLIMutable>] TransactionPartnerTelegramApi =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "telegram_api")>] TransactionPartnerTelegramApi =
   {
     /// Type of the transaction partner, always “telegram_api”
     [<DataMember(Name = "type")>]
@@ -9542,7 +9542,7 @@ and [<CLIMutable>] TransactionPartnerTelegramApi =
     }
 
 /// Describes a transaction with an unknown source or recipient.
-and [<CLIMutable>] TransactionPartnerOther =
+and [<CLIMutable; Funogram.Types.TelegramTag("type", "other")>] TransactionPartnerOther =
   {
     /// Type of the transaction partner, always “other”
     [<DataMember(Name = "type")>]

--- a/src/Funogram.Tests/Funogram.Tests.fsproj
+++ b/src/Funogram.Tests/Funogram.Tests.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Constants.fs" />
     <Compile Include="Extensions.fs" />
     <Compile Include="Json.fs" />
+    <Compile Include="UnionDiscriminators.fs" />
     <Compile Include="Core.fs" />
     <Compile Include="Deserializer.fs" />
   </ItemGroup>

--- a/src/Funogram.Tests/UnionDiscriminators.fs
+++ b/src/Funogram.Tests/UnionDiscriminators.fs
@@ -1,0 +1,96 @@
+module Funogram.Tests.UnionDiscriminators
+
+open Funogram.Telegram.Types
+open Xunit
+open Helpers
+
+// ChatMember subtypes are discriminated by the VALUE of the "status" field
+// (https://core.telegram.org/bots/api#chatmember). Several cases are
+// shape-identical (e.g. ChatMemberLeft and ChatMemberMember are both
+// {status, user} on the wire), so the converter must select the case by the
+// discriminator value — shape matching alone cannot be correct.
+
+let private caseName (m: ChatMember) =
+  match m with
+  | ChatMember.Owner _ -> "Owner"
+  | ChatMember.Administrator _ -> "Administrator"
+  | ChatMember.Member _ -> "Member"
+  | ChatMember.Restricted _ -> "Restricted"
+  | ChatMember.Left _ -> "Left"
+  | ChatMember.Banned _ -> "Banned"
+
+let private user = """{"id":42,"is_bot":false,"first_name":"x"}"""
+
+/// Tools.parseJson expects the Telegram {"ok":true,"result":...} envelope.
+let private parseResult<'a> (payload: string) : Result<'a, Funogram.Types.ApiResponseError> =
+  parseJson<'a> ("""{"ok":true,"result":""" + payload + "}")
+
+[<Theory>]
+[<InlineData("creator", """{"status":"creator","user":%USER%,"is_anonymous":false}""", "Owner")>]
+[<InlineData("administrator", """{"status":"administrator","user":%USER%,"is_anonymous":false,"can_be_edited":false,"can_manage_chat":true,"can_delete_messages":true,"can_manage_video_chats":false,"can_restrict_members":true,"can_promote_members":false,"can_change_info":false,"can_invite_users":false,"can_post_stories":false,"can_edit_stories":false,"can_delete_stories":false}""", "Administrator")>]
+[<InlineData("member", """{"status":"member","user":%USER%}""", "Member")>]
+[<InlineData("restricted", """{"status":"restricted","user":%USER%,"is_member":true,"can_send_messages":false,"can_send_audios":false,"can_send_documents":false,"can_send_photos":false,"can_send_videos":false,"can_send_video_notes":false,"can_send_voice_notes":false,"can_send_polls":false,"can_send_other_messages":false,"can_add_web_page_previews":false,"can_change_info":false,"can_invite_users":false,"can_pin_messages":false,"can_manage_topics":false,"until_date":0}""", "Restricted")>]
+[<InlineData("left", """{"status":"left","user":%USER%}""", "Left")>]
+[<InlineData("kicked", """{"status":"kicked","user":%USER%,"until_date":0}""", "Banned")>]
+let ``ChatMember deserializes to the case matching the status value`` (status: string, jsonTemplate: string, expectedCase: string) =
+  let json = jsonTemplate.Replace("%USER%", user)
+  match parseResult<ChatMember> json with
+  | Ok m ->
+    Assert.Equal(expectedCase, caseName m)
+    // the wire status must survive on whichever case was chosen
+    let actualStatus =
+      match m with
+      | ChatMember.Owner x -> x.Status
+      | ChatMember.Administrator x -> x.Status
+      | ChatMember.Member x -> x.Status
+      | ChatMember.Restricted x -> x.Status
+      | ChatMember.Left x -> x.Status
+      | ChatMember.Banned x -> x.Status
+    Assert.Equal(status, actualStatus)
+  | Error e -> failwith e.Description
+
+[<Fact>]
+let ``ChatMember member round-trip does not invent fields`` () =
+  // A misdiscriminated {"status":"member"} used to come back as Owner and
+  // re-serialize with an is_anonymous field that was never on the wire.
+  let json = """{"status":"member","user":""" + user + "}"
+  match parseResult<ChatMember> json with
+  | Ok m ->
+    let reserialized = toJsonString m
+    Assert.DoesNotContain("is_anonymous", reserialized)
+  | Error e -> failwith e.Description
+
+[<Fact>]
+let ``ChatMember with an unknown future status falls back to shape matching without throwing`` () =
+  // Forward compatibility: when Telegram introduces a status this library version
+  // doesn't know, deserialization must not fail; the wire status is still readable.
+  let json = """{"status":"holographic_member","user":""" + user + "}"
+  match parseResult<ChatMember> json with
+  | Ok m ->
+    let status =
+      match m with
+      | ChatMember.Owner x -> x.Status
+      | ChatMember.Administrator x -> x.Status
+      | ChatMember.Member x -> x.Status
+      | ChatMember.Restricted x -> x.Status
+      | ChatMember.Left x -> x.Status
+      | ChatMember.Banned x -> x.Status
+    Assert.Equal("holographic_member", status)
+  | Error e -> failwith e.Description
+
+[<Theory>]
+[<InlineData("""{"type":"user","date":1,"sender_user":{"id":1,"is_bot":false,"first_name":"x"}}""", "User")>]
+[<InlineData("""{"type":"hidden_user","date":1,"sender_user_name":"x"}""", "HiddenUser")>]
+[<InlineData("""{"type":"chat","date":1,"sender_chat":{"id":-1,"type":"channel"}}""", "Chat")>]
+[<InlineData("""{"type":"channel","date":1,"chat":{"id":-1,"type":"channel"},"message_id":5}""", "Channel")>]
+let ``MessageOrigin deserializes to the case matching the type value`` (json: string, expectedCase: string) =
+  match parseResult<MessageOrigin> json with
+  | Ok o ->
+    let actual =
+      match o with
+      | MessageOrigin.User _ -> "User"
+      | MessageOrigin.HiddenUser _ -> "HiddenUser"
+      | MessageOrigin.Chat _ -> "Chat"
+      | MessageOrigin.Channel _ -> "Channel"
+    Assert.Equal(expectedCase, actual)
+  | Error e -> failwith e.Description

--- a/src/Funogram/Converters.fs
+++ b/src/Funogram/Converters.fs
@@ -78,14 +78,18 @@ module internal Converters =
     | Nullary of name: string
     | Scalar  of clrType: Type
     | Array
-    | Object  of props: Set<string>
+    /// tag = (discriminator property name, expected value) from TelegramTagAttribute,
+    /// for subtypes discriminated by a field value rather than by shape.
+    | Object  of props: Set<string> * tag: (string * string) option
 
   [<RequireQualifiedAccess>]
   type private JsonShape =
     | String of value: string
     | Scalar of candidateTypes: Type list
     | Array
-    | Object of props: string list
+    /// Top-level property names, with the value kept for string-valued properties
+    /// (candidates for a discriminator tag).
+    | Object of props: (string * string option) list
 
   let private fsharpListTypeDef = typedefof<_ list>
 
@@ -114,10 +118,17 @@ module internal Converters =
           elif isArrayLike tp then
             CaseDescriptor.Array
           else
-            tp.GetProperties()
-            |> Seq.map (fun x -> x.Name |> toSnakeCase)
-            |> Set.ofSeq
-            |> CaseDescriptor.Object)
+            let props =
+              tp.GetProperties()
+              |> Seq.map (fun x -> x.Name |> toSnakeCase)
+              |> Set.ofSeq
+            let tag =
+              tp.GetCustomAttributes(typeof<Funogram.Types.TelegramTagAttribute>, false)
+              |> Seq.tryHead
+              |> Option.map (fun a ->
+                let a = a :?> Funogram.Types.TelegramTagAttribute
+                a.Field, a.Value)
+            CaseDescriptor.Object (props, tag))
       |> Seq.toArray
     
     let serializers =
@@ -147,13 +158,30 @@ module internal Converters =
       | JsonTokenType.StartArray ->
         JsonShape.Array
       | JsonTokenType.StartObject ->
-        let props = List<string>()
+        let props = List<string * string option>()
         let mutable loop = reader.Read()
         while loop do
           match reader.TokenType with
           | JsonTokenType.PropertyName ->
-            props.Add(reader.GetString())
+            let name = reader.GetString()
             loop <- reader.Read()
+            if loop then
+              match reader.TokenType with
+              | JsonTokenType.String ->
+                // keep string values: they are discriminator-tag candidates
+                props.Add(name, Some (reader.GetString()))
+                loop <- reader.Read()
+              | JsonTokenType.StartObject
+              | JsonTokenType.StartArray ->
+                props.Add(name, None)
+                reader.Skip()
+                loop <- reader.Read()
+              | JsonTokenType.EndObject ->
+                props.Add(name, None)
+                loop <- false
+              | _ ->
+                props.Add(name, None)
+                loop <- reader.Read()
           | JsonTokenType.StartObject
           | JsonTokenType.StartArray ->
             reader.Skip()
@@ -167,24 +195,38 @@ module internal Converters =
         JsonShape.Object []
     
     override x.Read(reader, _, options) =
-      let resolveObject (props: string list) =
-        let exact =
+      let resolveObject (props: (string * string option) list) =
+        // 1) Discriminator value: a case tagged (field, value) wins when the JSON
+        //    carries exactly that value (e.g. {"status":"member"} -> ChatMember.Member).
+        //    Shape matching cannot do this — some subtypes are shape-identical.
+        let byTag =
           cases
           |> Array.tryFindIndex (function
-             | CaseDescriptor.Object known -> props |> List.forall known.Contains
+             | CaseDescriptor.Object (_, Some (tagField, tagValue)) ->
+               props |> List.exists (fun (n, v) -> n = tagField && v = Some tagValue)
              | _ -> false)
-        match exact with
-        | Some _ -> exact
+        match byTag with
+        | Some _ -> byTag
         | None ->
-          let scored =
+          // 2) Shape fallback (untagged unions, or an unknown future tag value).
+          let names = props |> List.map fst
+          let exact =
             cases
-            |> Array.mapi (fun i c ->
-              match c with
-              | CaseDescriptor.Object known ->
-                i, props |> List.sumBy (fun n -> if known.Contains n then 1 else 0)
-              | _ -> i, -1)
-          let i, best = scored |> Array.maxBy snd
-          if best < 0 then None else Some i
+            |> Array.tryFindIndex (function
+               | CaseDescriptor.Object (known, _) -> names |> List.forall known.Contains
+               | _ -> false)
+          match exact with
+          | Some _ -> exact
+          | None ->
+            let scored =
+              cases
+              |> Array.mapi (fun i c ->
+                match c with
+                | CaseDescriptor.Object (known, _) ->
+                  i, names |> List.sumBy (fun n -> if known.Contains n then 1 else 0)
+                | _ -> i, -1)
+            let i, best = scored |> Array.maxBy snd
+            if best < 0 then None else Some i
 
       let idx =
         match x.ReadShape(&reader) with

--- a/src/Funogram/Types.fs
+++ b/src/Funogram/Types.fs
@@ -11,6 +11,18 @@ type IBotLogger =
   abstract member Log: message: string -> unit
   abstract member Enabled: bool
 
+/// Marks a generated Telegram type as a tag-discriminated union payload: the JSON
+/// property `Field` always carries the literal `Value` for this subtype (e.g.
+/// ChatMemberOwner -> ("status", "creator")). The union converter uses it to select
+/// the case by discriminator value; several subtypes (ChatMemberLeft vs
+/// ChatMemberMember) are shape-identical on the wire, so field-shape matching alone
+/// cannot discriminate them.
+[<AttributeUsage(AttributeTargets.Class, AllowMultiple = false)>]
+type TelegramTagAttribute(field: string, value: string) =
+  inherit Attribute()
+  member _.Field = field
+  member _.Value = value
+
 type BotConfig = 
   { IsTest: bool
     Token: string


### PR DESCRIPTION
## The bug

`DiscriminatedUnionConverter` selects union cases by **field-shape overlap**, ignoring the discriminator value Telegram actually uses. For `ChatMember` this cannot work: `ChatMemberLeft` and `ChatMemberMember` are shape-identical on the wire (`{status, user}`), and the first shape-superset wins, so:

- `{"status":"member","user":…}` deserializes as **`Owner`**
- `{"status":"left","user":…}` deserializes as **`Owner`**
- `{"status":"kicked","user":…,"until_date":0}` deserializes as **`Member`**

Re-serializing a misdiscriminated value also invents fields that were never on the wire (`is_anonymous: false` from `Owner`'s required fields). Any consumer pattern-matching `ChatMember` (e.g. `getChatMember`-based permission checks) silently gets wrong cases. Other tag-discriminated unions (`MessageOrigin`, `ReactionType`, …) currently work only because their shapes happen to be distinct — one Bot API update away from breaking the same way.

## The fix

Select the case by the discriminator **value**, with shape matching kept as the fallback:

1. **`Funogram.Types.TelegramTagAttribute(field, value)`** (core) marks a generated record as a tag-discriminated union payload — the Bot API documents the fixed value as *"always "X""* on the field (e.g. `ChatMemberOwner.status` is *always "creator"*).
2. **Converter**: while shape-reading an object, top-level string property values are captured; a case whose tag `(field, value)` matches the JSON wins. Unions without tags — and *unknown future tag values* — fall back to the existing shape-based resolution, so behavior is strictly corrected, never narrowed (forward compat covered by a test).
3. **Generator**: parses *"always "X""* from required string-field descriptions and emits the attribute, so every future regeneration keeps the tags. The checked-in `Types.fs` is updated the same way: **91 subtypes** across `ChatMember`, `MessageOrigin`, `ReactionType`, `PaidMedia`, `ChatBoostSource`, `BackgroundType`/`BackgroundFill`, `StoryAreaType`, `OwnedGift`, `RichText`, `PageBlock`, ….

## Tests

New `UnionDiscriminators.fs`:
- all six `ChatMember` statuses parse to the correct case (three failed before this fix);
- round-trip of `{"status":"member"}` no longer invents `is_anonymous`;
- an unknown future status (`"holographic_member"`) still parses without throwing and preserves the wire status;
- `MessageOrigin` matrix keeps passing.

Full suite: 39/39 green; solution builds with 0 warnings.

Found while migrating two production bots from Telegram.Bot to Funogram — happy to adjust naming/approach if you'd prefer a different mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)