### PR TITLE
Funogram.Tools: expose the JSON serialization options

### DIFF
--- a/src/Funogram/Tools.fs
+++ b/src/Funogram/Tools.fs
@@ -76,7 +76,12 @@ module internal RequestLogger =
     logger.Text.Append("Res: ").Append(e.ToString()) |> ignore
     logger.Logger.Log(logger.Text.ToString())
 
-let internal options =
+/// Shared JSON serializer settings used by Funogram for request and response payloads.
+///
+/// Reuse this instance when serializing or deserializing Funogram types so external code
+/// stays aligned with the library's snake_case wire format, union handling, Unix timestamps,
+/// and null-skipping behavior.
+let options =
   let o =
     JsonSerializerOptions(
       WriteIndented = false,


### PR DESCRIPTION
Otherwise, people have to build contraptions to get this field: https://github.com/Szer/bots/blob/f1ab1f5b83186653cfac2971869cdc0296d821ff/src/BotInfra/TelegramApi.fs#L12-L43